### PR TITLE
Added new constants to JSON constants.xml

### DIFF
--- a/reference/json/constants.xml
+++ b/reference/json/constants.xml
@@ -136,6 +136,32 @@
     </para>
    </listitem>
   </varlistentry>
+  <varlistentry xml:id="constant.json-error-invalid-property-name">
+   <term>
+    <constant>JSON_ERROR_INVALID_PROPERTY_NAME</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <para>
+     Se ha usado una clave que empieza con el caracter \u0000 en la cadena
+     de texto pasada a <function>json_encode()</function> al decodificar
+     un objeto JSON en un objeto PHP.
+    </para>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.json-error-utf16">
+   <term>
+    <constant>JSON_ERROR_UTF16</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <para>
+     Un único sustituto UTF-16 no emparejado en una secuencia de escape
+     unicode contenida en la cadena JSON pasada a
+     <function>json_encode()</function>.
+    </para>
+   </listitem>
+  </varlistentry>
  </variablelist>
  
  <para>
@@ -226,6 +252,19 @@
     <simpara>
      Codifica integer grandes como su valor del string original.
      Disponible desde PHP 5.4.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="constant.json-object-as-array">
+   <term>
+    <constant>JSON_OBJECT_AS_ARRAY</constant>
+    (<type>integer</type>)
+   </term>
+   <listitem>
+    <simpara>
+     Decodifica objetos JSON como arrays de PHP. Esta opción se puede
+     añadir automáticamente llamando a <function>json_decode()</function> con el segundo
+     parámetro igual a &true;
     </simpara>
    </listitem>
   </varlistentry>
@@ -349,6 +388,18 @@
      <constant>JSON_PARTIAL_OUTPUT_ON_ERROR</constant> tiene prioridad sobre
      <constant>JSON_THROW_ON_ERROR</constant>.
      Disponible desde PHP 7.3.0.
+    </simpara>
+   </listitem>
+  </varlistentry>
+  <varlistentry xml:id="onstant.json-error-non-backed-enum">
+   <term>
+    <constant>JSON_ERROR_NON_BACKED_ENUM</constant>
+    (<type>int</type>)
+   </term>
+   <listitem>
+    <simpara>
+     El valor pasado a <function>json_encode</function> incluye un enum
+     no respaldado que no se puede serializar. Disponible desde PHP 8.1.0.
     </simpara>
    </listitem>
   </varlistentry>

--- a/reference/json/constants.xml
+++ b/reference/json/constants.xml
@@ -19,7 +19,6 @@
    <listitem>
     <simpara>
      No ha ocurrido ningún error.
-     Disponible desde PHP 5.3.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -31,7 +30,6 @@
    <listitem>
     <simpara>
      Se ha excedido la profundidad máxima de la pila.
-     Disponible desde PHP 5.3.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -43,7 +41,6 @@
    <listitem>
     <simpara>
      Por desbordamiento de buffer o cuando los modos no coinciden.
-     Disponible desde PHP 5.3.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -55,7 +52,6 @@
    <listitem>
     <simpara>
      Error del carácter de control, posiblemente se ha codificado de forma incorrecta.
-     Disponible desde PHP 5.3.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -67,7 +63,6 @@
    <listitem>
     <simpara>
      Error de sintaxis.
-     Disponible desde PHP 5.3.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -78,8 +73,7 @@
    </term>
    <listitem>
     <simpara>
-     Caracteres UTF-8 mal formados, posiblemente codificados incorrectamente. Esta
-     constante está disponible desde PHP 5.3.3.
+     Caracteres UTF-8 mal formados, posiblemente codificados incorrectamente.
     </simpara>
    </listitem>
   </varlistentry>
@@ -94,9 +88,6 @@
      referencias recursivas y no se puede codificar.
      Si se proporcionó la opción <constant>JSON_PARTIAL_OUTPUT_ON_ERROR</constant>,
      se codificará &null; en el lugar de la referencia recursiva.
-    </para>
-    <para>
-     Esta constante está disponible a partir de PHP 5.5.0.
     </para>
    </listitem>
   </varlistentry>
@@ -114,9 +105,6 @@
      se codificará <literal>0</literal> en el lugar de estos números
      especiales.
     </para>
-    <para>
-     Esta constante está disponible a partir de PHP 5.5.0.
-    </para>
    </listitem>
   </varlistentry>
   <varlistentry xml:id="constant.json-error-unsupported-type">
@@ -130,9 +118,6 @@
      <function>json_encode</function>, tal como un <type>resource</type>.
      Si se proporcionó la opción <constant>JSON_PARTIAL_OUTPUT_ON_ERROR</constant>,
      se codificará &null; en el lugar del valor no admitido.
-    </para>
-    <para>
-     Esta constante está disponible a partir de PHP 5.5.0.
     </para>
    </listitem>
   </varlistentry>
@@ -177,7 +162,6 @@
    <listitem>
     <simpara>
      Todos los &lt; y &gt; se convierten a \u003C y \u003E.
-     Disponible desde PHP 5.3.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -189,7 +173,6 @@
    <listitem>
     <simpara>
      Todos los &amp; se convierten a \u0026.
-     Disponible desde PHP 5.3.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -201,7 +184,6 @@
    <listitem>
     <simpara>
      Todas las ' se convierten a \u0027.
-     Disponible desde PHP 5.3.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -212,8 +194,7 @@
    </term>
    <listitem>
     <simpara>
-     Todas las " se convierten a  \u0022.
-     Disponible desde PHP 5.3.0.
+     Todas las " se convierten a \u0022.
     </simpara>
    </listitem>
   </varlistentry>
@@ -227,7 +208,6 @@
      Devuelve un objeto en vez de un array cuando se usa un array no
      asociativo. Especialmente útil cuando el destinatario del resultado espera
      un objeto y el array está vacío.
-     Disponible desde PHP 5.3.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -239,7 +219,6 @@
    <listitem>
     <simpara>
      Codifica textos numéricos como números.
-     Disponible desde PHP 5.3.3.
     </simpara>
    </listitem>
   </varlistentry>
@@ -251,7 +230,6 @@
    <listitem>
     <simpara>
      Codifica integer grandes como su valor del string original.
-     Disponible desde PHP 5.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -276,7 +254,6 @@
    <listitem>
     <simpara>
      Utiliza espacios en blanco para formatear los datos devueltos.
-     Disponible desde PHP 5.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -288,7 +265,6 @@
    <listitem>
     <simpara>
      No escapar <literal>/</literal>.
-     Disponible desde PHP 5.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -300,7 +276,6 @@
    <listitem>
     <simpara>
      Codificar caracteres Unicode multibyte literalmente (por defecto es escapado como \uXXXX).
-     Disponible desde PHP 5.4.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -312,7 +287,6 @@
    <listitem>
     <simpara>
      Sustituir algunos valores no codificables en lugar de fallar.
-     Disponible desde PHP 5.5.0.
     </simpara>
    </listitem>
   </varlistentry>
@@ -324,7 +298,6 @@
    <listitem>
     <simpara>
      Se asegura de que los valores <type>float</type> son siempre codificados como valores de punto flotante.
-     Disponible desde PHP 5.6.6.
     </simpara>
    </listitem>
   </varlistentry>


### PR DESCRIPTION
Added JSON_ERROR_INVALID_PROPERTY_NAME, JSON_ERROR_UTF16, JSON_OBJECT_AS_ARRAY and JSON_ERROR_NON_BACKED_ENUM from https://github.com/php/doc-en/blob/master/reference/json/constants.xml